### PR TITLE
SL-21367 fix no method error on nil response

### DIFF
--- a/lib/autodiscover/pox_response.rb
+++ b/lib/autodiscover/pox_response.rb
@@ -17,15 +17,21 @@ module Autodiscover
     end
 
     def exch_proto
-      @exch_proto ||= (response["Account"]["Protocol"].select{|p| p["Type"] == "EXCH"}.first || {})
+      @exch_proto ||= protocols.find { |p| p["Type"] == "EXCH" } || {}
     end
 
     def expr_proto
-      @expr_proto ||= (response["Account"]["Protocol"].select{|p| p["Type"] == "EXPR"}.first || {})
+      @expr_proto ||= protocols.find { |p| p["Type"] == "EXPR" } || {}
     end
 
     def web_proto
-      @web_proto ||= (response["Account"]["Protocol"].select{|p| p["Type"] == "WEB"}.first || {})
+      @web_proto ||= protocols.find { |p| p["Type"] == "WEB" } || {}
+    end
+
+    private
+
+    def protocols
+      response["Account"]["Protocol"] || []
     end
 
   end

--- a/lib/autodiscover/version.rb
+++ b/lib/autodiscover/version.rb
@@ -1,3 +1,3 @@
 module Autodiscover
-  VERSION = "1.0.3"
+  VERSION = "1.0.4"
 end

--- a/test/units/pox_response_test.rb
+++ b/test/units/pox_response_test.rb
@@ -49,6 +49,12 @@ describe Autodiscover::PoxResponse do
       _(_inst.expr_proto).must_equal({})
       _(_inst.web_proto).must_equal({})
     end
-  end
 
+    it "returns empty Hashes when the Account has no protocols" do
+      _inst.response["Account"].delete("Protocol")
+      _(_inst.exch_proto).must_equal({})
+      _(_inst.expr_proto).must_equal({})
+      _(_inst.web_proto).must_equal({})
+    end
+  end
 end

--- a/test/units/pox_response_test.rb
+++ b/test/units/pox_response_test.rb
@@ -18,7 +18,7 @@ describe Autodiscover::PoxResponse do
 
   describe "#exchange_version" do
     it "returns an Exchange version usable for EWS" do
-      _(_class.new(response).exchange_version).must_equal "Exchange2013_SP1"
+      _(_class.new(response).exchange_version).must_equal "Exchange2016"
     end
   end
 


### PR DESCRIPTION
https://salesloft.atlassian.net/browse/SL-21367

# Bug Fix
Previously, when an autodiscover response contained no Account->Protocols, a `NoMethodError` was raised because `select` was called on `nil`. This handles that scenario and returns a default empty hash like the main response methods already do for their return contract.